### PR TITLE
Fix JaCoCo check and Docker tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
         working-directory: ./backend
         run: |
           echo "Verifying coverage meets 80% threshold..."
-          mvn jacoco:check -B
+          mvn verify -DskipTests -DskipITs -B
         env:
           MAVEN_OPTS: "-Xmx2048m"
       
@@ -212,7 +212,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-,suffix=-{{date 'YYYYMMDD-HHmmss'}}
+            type=sha,prefix=sha-,suffix=-{{date 'YYYYMMDD-HHmmss'}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
       
@@ -225,7 +225,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-,suffix=-{{date 'YYYYMMDD-HHmmss'}}
+            type=sha,prefix=sha-,suffix=-{{date 'YYYYMMDD-HHmmss'}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
       

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -181,6 +181,7 @@
                     </execution>
                     <execution>
                         <id>jacoco-check</id>
+                        <phase>verify</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
## Summary
- run coverage check during `verify` phase
- update workflow to use `mvn verify`
- ensure docker image tags are valid

## Testing
- `pnpm install --frozen-lockfile` *(fails: pnpm-lock.yaml is absent)*

------
https://chatgpt.com/codex/tasks/task_e_686d6c2044a883308122c9275c70396c