### PR TITLE
feat: add synthetic market intelligence service and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
-# energy-market-visualization
+# Energy Market Visualization
+
+An applied-intelligence sandbox that generates premium electricity market telemetry for product and
+analytics experiments. The project ships a synthetic Spring Boot WebFlux API and a modern React
+analytics console designed for latency-sensitive price discovery and risk monitoring.
+
+## Capabilities
+
+- **High-signal synthetic data** – deterministic scenario engine produces price, load, carbon
+  intensity and renewable penetration curves for five major North American ISOs.
+- **Insightful analytics** – volatility, carbon trend and anomaly detection metrics summarise the
+  current operating window.
+- **Forward-looking forecasts** – price envelope projections with confidence bands to gauge short
+  term risk.
+- **Interactive dashboard** – React 19 + React Query interface with Tailwind styling, real-time
+  refresh indicators and multi-market comparison cards.
+
+## Backend (Spring Boot 3 / Java 22)
+
+The backend lives in [`backend/`](backend/) and exposes reactive JSON endpoints under
+`/api/markets`:
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /api/markets/catalog` | Market catalogue with region, timezone and descriptive context. |
+| `GET /api/markets/overview` | Portfolio view of current price, demand and sustainability metrics. |
+| `GET /api/markets/{code}/snapshot` | Composite response with historical series, forecast and insights. |
+
+Synthetic data is produced by `MarketDataGenerator`, which combines seasonal shapes, deterministic
+noise and anomaly detection to deliver realistic yet reproducible datasets. Tests exercise service
+logic and the REST controller using `WebTestClient`.
+
+### Running the backend
+
+```bash
+cd backend
+mvn spring-boot:run
+```
+
+### Backend quality gates
+
+```bash
+cd backend
+mvn spotless:apply   # optional auto-format
+mvn test             # unit tests + coverage rules
+```
+
+## Frontend (React 19 + Vite + Tailwind)
+
+The frontend dashboard resides in [`frontend/`](frontend/). It uses TanStack Query to orchestrate
+API calls, Chart.js for price visualisation and Tailwind CSS for theming.
+
+### Available scripts
+
+```bash
+cd frontend
+npm install
+npm run dev          # start Vite dev server on http://localhost:3000
+npm run build        # production build
+npm run test         # Vitest unit tests (watch mode)
+npm run test:ci      # Vitest in coverage mode
+npm run lint         # ESLint
+npm run type-check   # TypeScript compiler checks
+```
+
+### Key UI features
+
+- Market picker with history/forecast controls and refresh action.
+- Overview grid displaying price movements, demand and sustainability metrics across markets.
+- Dual-axis price & demand chart backed by Chart.js (mocked in tests).
+- Forecast table summarising confidence bounds for upcoming hours.
+- Insights panel showing volatility, demand statistics and operational alerts.
+
+## Contributing
+
+1. Ensure Node.js 20+, npm 10+ and Java 22+ are installed.
+2. Run `scripts/pre-commit-quality-check.sh` to execute the combined quality gates.
+3. Submit focused changes with accompanying tests.
+
+---
+
+This repository is optimised for demonstrating intelligence-driven energy analytics without
+requiring live market data access.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Spring Boot -->
-        <spring.boot.version>3.5.3</spring.boot.version>
+        <spring.boot.version>3.3.2</spring.boot.version>
         
         <!-- Quality Gates -->
         <sonar.organization>energy-market-visualization</sonar.organization>

--- a/backend/src/main/java/com/energymarket/config/ClockConfiguration.java
+++ b/backend/src/main/java/com/energymarket/config/ClockConfiguration.java
@@ -1,0 +1,26 @@
+package com.energymarket.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides application wide time configuration.
+ *
+ * <p>Having the clock as a managed bean enables deterministic testing and a single source of
+ * truth for all time based calculations across the service.
+ */
+@Configuration
+public class ClockConfiguration {
+
+  /**
+   * Exposes the system UTC clock so time calculations are consistent and easily overridden in
+   * tests.
+   *
+   * @return the system UTC clock
+   */
+  @Bean
+  public Clock systemClock() {
+    return Clock.systemUTC();
+  }
+}

--- a/backend/src/main/java/com/energymarket/market/MarketCode.java
+++ b/backend/src/main/java/com/energymarket/market/MarketCode.java
@@ -1,0 +1,138 @@
+package com.energymarket.market;
+
+import com.energymarket.market.model.MarketMetadata;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Enumeration of the synthetic markets supported by the demo service.
+ */
+public enum MarketCode {
+  CAISO(
+      "CAISO",
+      "California ISO Day-Ahead",
+      "US West Coast",
+      "America/Los_Angeles",
+      "High solar penetration with daily two-peak demand curves.",
+      new MarketParameters(75.0, 20.0, 7.0, 5.1, 0.7, 28000.0, 5000.0, 280.0, 25.0, 56.0, 15.0)),
+  ERCOT(
+      "ERCOT",
+      "ERCOT Real-Time Hub",
+      "Texas Interconnection",
+      "America/Chicago",
+      "Weather-sensitive grid with rapid ramping requirements.",
+      new MarketParameters(70.0, 22.0, 8.0, 6.0, 1.2, 48000.0, 9000.0, 420.0, 45.0, 32.0, 18.0)),
+  MISO(
+      "MISO",
+      "MISO North Hub",
+      "Midcontinent",
+      "America/Chicago",
+      "Wind-driven supply mix with large geographic footprint.",
+      new MarketParameters(60.0, 14.0, 5.0, 3.8, 0.5, 42000.0, 7200.0, 360.0, 28.0, 38.0, 10.0)),
+  NEISO(
+      "NEISO",
+      "ISO New England Hub",
+      "New England",
+      "America/New_York",
+      "Tight reserve margins and significant winter peak risk.",
+      new MarketParameters(85.0, 18.0, 6.5, 4.5, 0.8, 16500.0, 3200.0, 310.0, 35.0, 48.0, 12.0)),
+  PJM(
+      "PJM",
+      "PJM Western Hub",
+      "US Mid-Atlantic",
+      "America/New_York",
+      "Largest ISO with diverse generation fleet and congestion dynamics.",
+      new MarketParameters(65.0, 15.0, 5.5, 4.2, 0.6, 58000.0, 10500.0, 410.0, 30.0, 28.0, 8.0));
+
+  private final String code;
+  private final String name;
+  private final String region;
+  private final String timezone;
+  private final String description;
+  private final MarketParameters parameters;
+
+  MarketCode(
+      String code,
+      String name,
+      String region,
+      String timezone,
+      String description,
+      MarketParameters parameters) {
+    this.code = code;
+    this.name = name;
+    this.region = region;
+    this.timezone = timezone;
+    this.description = description;
+    this.parameters = parameters;
+  }
+
+  public String code() {
+    return code;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public String region() {
+    return region;
+  }
+
+  public String timezone() {
+    return timezone;
+  }
+
+  public String description() {
+    return description;
+  }
+
+  public MarketParameters parameters() {
+    return parameters;
+  }
+
+  /**
+   * Converts a textual market code to the enum instance in a case-insensitive manner.
+   *
+   * @param value the value to parse
+   * @return the matching market code, or empty if the value is unknown
+   */
+  public static Optional<MarketCode> fromCode(String value) {
+    if (value == null) {
+      return Optional.empty();
+    }
+    final String normalized = value.trim().toUpperCase(Locale.US);
+    return Arrays.stream(values()).filter(code -> Objects.equals(code.code, normalized)).findFirst();
+  }
+
+  /**
+   * Creates a lightweight metadata view used by clients to render selectors and contextual text.
+   *
+   * @return immutable metadata record
+   */
+  public MarketMetadata toMetadata() {
+    return new MarketMetadata(code, name, region, timezone, description, parameters.basePrice());
+  }
+
+  @Override
+  public String toString() {
+    return code;
+  }
+
+  /**
+   * Domain-specific tuning parameters that drive the synthetic dataset for each market.
+   */
+  public record MarketParameters(
+      double basePrice,
+      double dailySwing,
+      double weeklySwing,
+      double volatility,
+      double trendSlope,
+      double demandBase,
+      double demandSwing,
+      double carbonBase,
+      double carbonSwing,
+      double renewableBase,
+      double renewableSwing) {}
+}

--- a/backend/src/main/java/com/energymarket/market/api/ApiExceptionHandler.java
+++ b/backend/src/main/java/com/energymarket/market/api/ApiExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.energymarket.market.api;
+
+import com.energymarket.market.exception.MarketNotFoundException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Centralised error handling for the market API, returning RFC7807 responses.
+ */
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+  @ExceptionHandler(MarketNotFoundException.class)
+  public ProblemDetail handleMarketNotFound(MarketNotFoundException exception) {
+    ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+    problem.setTitle("Market not found");
+    problem.setDetail(exception.getMessage());
+    return problem;
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ProblemDetail handleIllegalArgument(IllegalArgumentException exception) {
+    ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+    problem.setTitle("Invalid request parameter");
+    problem.setDetail(exception.getMessage());
+    return problem;
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ProblemDetail handleConstraintViolation(ConstraintViolationException exception) {
+    ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+    problem.setTitle("Validation failed");
+    problem.setDetail("Request parameters failed validation");
+    Map<String, String> violations =
+        exception.getConstraintViolations().stream()
+            .collect(
+                Collectors.toMap(
+                    ApiExceptionHandler::extractViolationProperty,
+                    ConstraintViolation::getMessage));
+    problem.setProperty("violations", violations);
+    return problem;
+  }
+
+  private static String extractViolationProperty(ConstraintViolation<?> violation) {
+    String path = violation.getPropertyPath().toString();
+    int lastDot = path.lastIndexOf('.');
+    return lastDot >= 0 ? path.substring(lastDot + 1) : path;
+  }
+}

--- a/backend/src/main/java/com/energymarket/market/api/MarketController.java
+++ b/backend/src/main/java/com/energymarket/market/api/MarketController.java
@@ -1,0 +1,63 @@
+package com.energymarket.market.api;
+
+import com.energymarket.market.model.MarketMetadata;
+import com.energymarket.market.model.MarketOverview;
+import com.energymarket.market.model.MarketSnapshot;
+import com.energymarket.market.service.MarketDataService;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.util.List;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive REST controller exposing the synthetic energy market intelligence API.
+ */
+@RestController
+@RequestMapping("/api/markets")
+@Validated
+public class MarketController {
+
+  private final MarketDataService marketDataService;
+
+  public MarketController(MarketDataService marketDataService) {
+    this.marketDataService = marketDataService;
+  }
+
+  /** Returns metadata for the available markets. */
+  @GetMapping("/catalog")
+  public Mono<List<MarketMetadata>> getMarketCatalog() {
+    return Mono.fromSupplier(marketDataService::getMarketCatalog);
+  }
+
+  /** Returns an overview for all markets to support comparison dashboards. */
+  @GetMapping("/overview")
+  public Mono<List<MarketOverview>> getMarketOverview() {
+    return Mono.fromSupplier(marketDataService::getMarketOverview);
+  }
+
+  /**
+   * Returns the detailed snapshot for a specific market.
+   */
+  @GetMapping("/{marketCode}/snapshot")
+  public Mono<MarketSnapshot> getMarketSnapshot(
+      @PathVariable String marketCode,
+      @RequestParam(defaultValue = "24") @Min(1) @Max(168) int historyHours,
+      @RequestParam(defaultValue = "15") @Min(5) @Max(180) int historyResolutionMinutes,
+      @RequestParam(defaultValue = "12") @Min(1) @Max(72) int forecastHours,
+      @RequestParam(defaultValue = "60") @Min(15) @Max(240) int forecastResolutionMinutes) {
+    return Mono.fromSupplier(
+        () ->
+            marketDataService.getMarketSnapshot(
+                marketCode,
+                historyHours,
+                historyResolutionMinutes,
+                forecastHours,
+                forecastResolutionMinutes));
+  }
+}

--- a/backend/src/main/java/com/energymarket/market/exception/MarketNotFoundException.java
+++ b/backend/src/main/java/com/energymarket/market/exception/MarketNotFoundException.java
@@ -1,0 +1,11 @@
+package com.energymarket.market.exception;
+
+/**
+ * Thrown when a requested market code does not match the supported catalogue.
+ */
+public class MarketNotFoundException extends RuntimeException {
+
+  public MarketNotFoundException(String code) {
+    super("Unknown market code: " + code);
+  }
+}

--- a/backend/src/main/java/com/energymarket/market/generator/MarketDataGenerator.java
+++ b/backend/src/main/java/com/energymarket/market/generator/MarketDataGenerator.java
@@ -1,0 +1,355 @@
+package com.energymarket.market.generator;
+
+import com.energymarket.market.MarketCode;
+import com.energymarket.market.MarketCode.MarketParameters;
+import com.energymarket.market.model.ForecastPoint;
+import com.energymarket.market.model.MarketInsights;
+import com.energymarket.market.model.MarketOverview;
+import com.energymarket.market.model.MarketSnapshot;
+import com.energymarket.market.model.PricePoint;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Generates deterministic, high-signal synthetic market data suitable for advanced UI demos.
+ */
+public class MarketDataGenerator {
+
+  private static final double MIN_PRICE = 20.0;
+  private static final double MIN_DEMAND_FACTOR = 0.5;
+  private static final double MIN_RENEWABLE_SHARE = 5.0;
+  private static final double MAX_RENEWABLE_SHARE = 95.0;
+  private static final double MIN_CARBON_INTENSITY = 80.0;
+
+  /**
+   * Builds a full dashboard snapshot including historical series, forecast and analytics.
+   */
+  public MarketSnapshot generateSnapshot(
+      MarketCode market,
+      Instant now,
+      Duration historyRange,
+      Duration historyInterval,
+      Duration forecastHorizon,
+      Duration forecastInterval) {
+    MarketContext context = buildContext(market, now, historyRange, historyInterval);
+    List<ForecastPoint> forecast =
+        buildForecast(
+            market,
+            context.history(),
+            forecastHorizon,
+            forecastInterval,
+            context.insights().priceStandardDeviation());
+    return new MarketSnapshot(context.overview(), context.history(), forecast, context.insights());
+  }
+
+  /** Returns a top-level overview for quick market comparisons. */
+  public MarketOverview generateOverview(
+      MarketCode market, Instant now, Duration historyRange, Duration historyInterval) {
+    return buildContext(market, now, historyRange, historyInterval).overview();
+  }
+
+  private MarketContext buildContext(
+      MarketCode market, Instant now, Duration historyRange, Duration historyInterval) {
+    List<PricePoint> history = buildHistoricalSeries(market, now, historyRange, historyInterval);
+    MarketInsights insights = buildInsights(market, history);
+    MarketOverview overview = buildOverview(market, history, insights);
+    return new MarketContext(overview, history, insights);
+  }
+
+  private List<PricePoint> buildHistoricalSeries(
+      MarketCode market, Instant now, Duration range, Duration interval) {
+    validateDurations(range, interval, "history");
+    long rangeMinutes = range.toMinutes();
+    long intervalMinutes = interval.toMinutes();
+    int steps = Math.toIntExact(rangeMinutes / intervalMinutes);
+
+    Instant start = now.minus(range);
+    ZoneId zoneId = ZoneId.of(market.timezone());
+    MarketParameters parameters = market.parameters();
+    List<PricePoint> series = new ArrayList<>(steps + 1);
+
+    for (int i = 0; i <= steps; i++) {
+      Instant timestamp = start.plus(interval.multipliedBy(i));
+      ZonedDateTime zoned = timestamp.atZone(zoneId);
+      double minutesOfDay = zoned.getHour() * 60.0 + zoned.getMinute();
+      double dayProgress = minutesOfDay / (24.0 * 60.0);
+      double weekProgress =
+          ((double) (zoned.getDayOfWeek().getValue() - 1) + dayProgress) / 7.0;
+      double hoursFromStart = (intervalMinutes * i) / 60.0;
+      double noise = computeNoise(timestamp, market.ordinal());
+
+      double price =
+          computePrice(parameters, hoursFromStart, dayProgress, weekProgress, noise);
+      double demand =
+          computeDemand(parameters, hoursFromStart, dayProgress, weekProgress, price, noise);
+      double renewables =
+          computeRenewables(parameters, hoursFromStart, dayProgress, weekProgress, noise);
+      double carbon = computeCarbon(parameters, demand, renewables);
+
+      series.add(
+          new PricePoint(
+              timestamp,
+              round(price, 2),
+              round(demand, 0),
+              round(carbon, 1),
+              round(renewables, 1)));
+    }
+
+    series.sort(Comparator.comparing(PricePoint::timestamp));
+    return List.copyOf(series);
+  }
+
+  private MarketInsights buildInsights(MarketCode market, List<PricePoint> history) {
+    Objects.requireNonNull(market, "market");
+    Objects.requireNonNull(history, "history");
+    if (history.isEmpty()) {
+      throw new IllegalArgumentException("history must contain at least one point");
+    }
+
+    PricePoint first = history.getFirst();
+    PricePoint last = history.getLast();
+
+    double priceSum = 0.0;
+    double priceSquareSum = 0.0;
+    double minPrice = Double.MAX_VALUE;
+    double maxPrice = Double.MIN_VALUE;
+    double demandSum = 0.0;
+    double peakDemand = Double.MIN_VALUE;
+    double renewableSum = 0.0;
+
+    for (PricePoint point : history) {
+      double price = point.priceMwh();
+      priceSum += price;
+      priceSquareSum += price * price;
+      minPrice = Math.min(minPrice, price);
+      maxPrice = Math.max(maxPrice, price);
+
+      double demand = point.demandMw();
+      demandSum += demand;
+      peakDemand = Math.max(peakDemand, demand);
+
+      renewableSum += point.renewablesShare();
+    }
+
+    int count = history.size();
+    double averagePrice = priceSum / count;
+    double variance = Math.max(0.0, priceSquareSum / count - averagePrice * averagePrice);
+    double priceStdDev = Math.sqrt(variance);
+    double averageDemand = demandSum / count;
+    double averageRenewables = renewableSum / count;
+    double hoursBetween =
+        Math.max(
+            1.0,
+            Duration.between(first.timestamp(), last.timestamp()).toMinutes() / 60.0);
+    double carbonTrend =
+        (last.carbonIntensity() - first.carbonIntensity()) / hoursBetween;
+
+    List<String> alerts = new ArrayList<>();
+    if (last.priceMwh() > averagePrice + (1.5 * priceStdDev)) {
+      double spikePercent =
+          ((last.priceMwh() - averagePrice) / averagePrice) * 100.0;
+      alerts.add(String.format("Price spike detected: +%.1f%% vs average", spikePercent));
+    }
+    if (last.demandMw() > peakDemand * 0.98) {
+      alerts.add("Demand is approaching the observed peak load");
+    }
+    if (last.renewablesShare() < averageRenewables - 8.0) {
+      alerts.add("Renewable output is significantly below typical levels");
+    }
+    if (carbonTrend > 1.0) {
+      alerts.add("Carbon intensity trending upward");
+    }
+
+    return new MarketInsights(
+        first.timestamp(),
+        last.timestamp(),
+        round(averagePrice, 2),
+        round(priceStdDev, 2),
+        round(minPrice, 2),
+        round(maxPrice, 2),
+        round(averageDemand, 0),
+        round(peakDemand, 0),
+        round(averageRenewables, 1),
+        round(carbonTrend, 2),
+        alerts);
+  }
+
+  private MarketOverview buildOverview(
+      MarketCode market, List<PricePoint> history, MarketInsights insights) {
+    PricePoint first = history.getFirst();
+    PricePoint last = history.getLast();
+    double priceDelta = last.priceMwh() - first.priceMwh();
+    double changePercent =
+        first.priceMwh() == 0.0 ? 0.0 : (priceDelta / first.priceMwh()) * 100.0;
+
+    return new MarketOverview(
+        market.code(),
+        market.name(),
+        market.region(),
+        market.timezone(),
+        market.description(),
+        round(last.priceMwh(), 2),
+        round(changePercent, 2),
+        insights.averagePrice(),
+        round(last.demandMw(), 0),
+        round(last.renewablesShare(), 1),
+        round(last.carbonIntensity(), 1),
+        round(market.parameters().basePrice(), 2),
+        last.timestamp());
+  }
+
+  private List<ForecastPoint> buildForecast(
+      MarketCode market,
+      List<PricePoint> history,
+      Duration horizon,
+      Duration interval,
+      double priceStdDev) {
+    validateDurations(horizon, interval, "forecast");
+    long horizonMinutes = horizon.toMinutes();
+    long intervalMinutes = interval.toMinutes();
+    int steps = Math.toIntExact(horizonMinutes / intervalMinutes);
+    if (steps == 0) {
+      return List.of();
+    }
+
+    PricePoint last = history.getLast();
+    Instant start = last.timestamp();
+    double slopePerHour = computePriceSlope(history);
+    MarketParameters parameters = market.parameters();
+    ZoneId zoneId = ZoneId.of(market.timezone());
+    double baseVolatility = priceStdDev <= 0.0 ? parameters.volatility() : priceStdDev;
+
+    List<ForecastPoint> forecast = new ArrayList<>(steps);
+    for (int i = 1; i <= steps; i++) {
+      Instant timestamp = start.plus(interval.multipliedBy(i));
+      ZonedDateTime zoned = timestamp.atZone(zoneId);
+      double minutesOfDay = zoned.getHour() * 60.0 + zoned.getMinute();
+      double dayProgress = minutesOfDay / (24.0 * 60.0);
+      double weekProgress =
+          ((double) (zoned.getDayOfWeek().getValue() - 1) + dayProgress) / 7.0;
+      double hoursAhead = (intervalMinutes * i) / 60.0;
+
+      double baseline = last.priceMwh() + slopePerHour * hoursAhead;
+      double seasonalDaily = parameters.dailySwing() * 0.35 * Math.sin(2 * Math.PI * dayProgress);
+      double seasonalWeekly =
+          parameters.weeklySwing() * 0.2 * Math.sin(2 * Math.PI * weekProgress);
+      double projected = baseline + seasonalDaily + seasonalWeekly;
+
+      double confidence = Math.max(parameters.volatility(), baseVolatility) * Math.sqrt(i);
+      double lower = Math.max(MIN_PRICE, projected - confidence);
+      double upper = projected + confidence;
+
+      forecast.add(
+          new ForecastPoint(
+              timestamp,
+              round(projected, 2),
+              round(lower, 2),
+              round(upper, 2)));
+    }
+
+    return List.copyOf(forecast);
+  }
+
+  private double computePriceSlope(List<PricePoint> history) {
+    if (history.size() < 2) {
+      return 0.0;
+    }
+    int lookback = Math.max(0, history.size() - 8);
+    PricePoint start = history.get(lookback);
+    PricePoint end = history.getLast();
+    double hours =
+        Math.max(1.0, Duration.between(start.timestamp(), end.timestamp()).toMinutes() / 60.0);
+    return (end.priceMwh() - start.priceMwh()) / hours;
+  }
+
+  private double computePrice(
+      MarketParameters parameters,
+      double hoursFromStart,
+      double dayProgress,
+      double weekProgress,
+      double noise) {
+    double daily = parameters.dailySwing() * Math.sin(2 * Math.PI * dayProgress);
+    double weekly = parameters.weeklySwing() * Math.sin(2 * Math.PI * weekProgress);
+    double structural = parameters.trendSlope() * (hoursFromStart / 24.0);
+    double stochastic = noise * parameters.volatility();
+    double value = parameters.basePrice() + daily + weekly + structural + stochastic;
+    return Math.max(MIN_PRICE, value);
+  }
+
+  private double computeDemand(
+      MarketParameters parameters,
+      double hoursFromStart,
+      double dayProgress,
+      double weekProgress,
+      double price,
+      double noise) {
+    double diurnal =
+        parameters.demandSwing()
+            * (1.1 - Math.cos(2 * Math.PI * dayProgress - Math.PI / 6));
+    double weekly = parameters.demandSwing() * 0.25 * Math.sin(2 * Math.PI * weekProgress);
+    double priceCoupling = (price - parameters.basePrice()) * 35.0;
+    double shortNoise = 180.0 * Math.sin(hoursFromStart / 4.5 + noise);
+    double demand = parameters.demandBase() + diurnal + weekly + priceCoupling + shortNoise;
+    return Math.max(parameters.demandBase() * MIN_DEMAND_FACTOR, demand);
+  }
+
+  private double computeRenewables(
+      MarketParameters parameters,
+      double hoursFromStart,
+      double dayProgress,
+      double weekProgress,
+      double noise) {
+    double solarShape =
+        parameters.renewableSwing() * Math.max(0.0, Math.sin(Math.PI * dayProgress));
+    double windShape = parameters.renewableSwing() * 0.35 * Math.sin(2 * Math.PI * weekProgress);
+    double intraDayVariance = 2.5 * Math.sin(hoursFromStart / 3.5 + noise);
+    double renewables =
+        parameters.renewableBase() + solarShape + windShape + intraDayVariance;
+    return clamp(renewables, MIN_RENEWABLE_SHARE, MAX_RENEWABLE_SHARE);
+  }
+
+  private double computeCarbon(MarketParameters parameters, double demand, double renewablesShare) {
+    double renewableFactor = 1.0 - (renewablesShare / 100.0);
+    double loadInfluence = 0.04 * (demand - parameters.demandBase());
+    double carbon = parameters.carbonBase() + parameters.carbonSwing() * renewableFactor + loadInfluence;
+    return Math.max(MIN_CARBON_INTENSITY, carbon);
+  }
+
+  private double computeNoise(Instant timestamp, int marketOrdinal) {
+    long minutes = timestamp.getEpochSecond() / 60;
+    double seed = minutes / 15.0 + marketOrdinal * 0.73;
+    return Math.sin(seed) + 0.4 * Math.cos(seed * 1.7);
+  }
+
+  private void validateDurations(Duration range, Duration interval, String label) {
+    if (range.isZero() || range.isNegative()) {
+      throw new IllegalArgumentException(label + " range must be positive");
+    }
+    if (interval.isZero() || interval.isNegative()) {
+      throw new IllegalArgumentException(label + " interval must be positive");
+    }
+    long rangeMinutes = range.toMinutes();
+    long intervalMinutes = interval.toMinutes();
+    if (rangeMinutes % intervalMinutes != 0) {
+      throw new IllegalArgumentException(label + " range must be divisible by its interval");
+    }
+  }
+
+  private double clamp(double value, double min, double max) {
+    return Math.max(min, Math.min(max, value));
+  }
+
+  private double round(double value, int digits) {
+    double factor = Math.pow(10, digits);
+    return Math.round(value * factor) / factor;
+  }
+
+  private record MarketContext(
+      MarketOverview overview, List<PricePoint> history, MarketInsights insights) {}
+}

--- a/backend/src/main/java/com/energymarket/market/model/ForecastPoint.java
+++ b/backend/src/main/java/com/energymarket/market/model/ForecastPoint.java
@@ -1,0 +1,14 @@
+package com.energymarket.market.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Forecasted price envelope for a future interval.
+ */
+public record ForecastPoint(Instant timestamp, double projectedPriceMwh, double lowerBound, double upperBound) {
+
+  public ForecastPoint {
+    Objects.requireNonNull(timestamp, "timestamp");
+  }
+}

--- a/backend/src/main/java/com/energymarket/market/model/MarketInsights.java
+++ b/backend/src/main/java/com/energymarket/market/model/MarketInsights.java
@@ -1,0 +1,28 @@
+package com.energymarket.market.model;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Statistical insights summarising market behaviour over a time window.
+ */
+public record MarketInsights(
+    Instant windowStart,
+    Instant windowEnd,
+    double averagePrice,
+    double priceStandardDeviation,
+    double minPrice,
+    double maxPrice,
+    double averageDemand,
+    double peakDemand,
+    double averageRenewablesShare,
+    double carbonIntensityTrendPerHour,
+    List<String> alerts) {
+
+  public MarketInsights {
+    Objects.requireNonNull(windowStart, "windowStart");
+    Objects.requireNonNull(windowEnd, "windowEnd");
+    alerts = List.copyOf(alerts);
+  }
+}

--- a/backend/src/main/java/com/energymarket/market/model/MarketMetadata.java
+++ b/backend/src/main/java/com/energymarket/market/model/MarketMetadata.java
@@ -1,0 +1,23 @@
+package com.energymarket.market.model;
+
+import java.util.Objects;
+
+/**
+ * Immutable metadata describing a wholesale electricity market.
+ */
+public record MarketMetadata(
+    String code,
+    String name,
+    String region,
+    String timezone,
+    String description,
+    double typicalPrice) {
+
+  public MarketMetadata {
+    Objects.requireNonNull(code, "code");
+    Objects.requireNonNull(name, "name");
+    Objects.requireNonNull(region, "region");
+    Objects.requireNonNull(timezone, "timezone");
+    Objects.requireNonNull(description, "description");
+  }
+}

--- a/backend/src/main/java/com/energymarket/market/model/MarketOverview.java
+++ b/backend/src/main/java/com/energymarket/market/model/MarketOverview.java
@@ -1,0 +1,32 @@
+package com.energymarket.market.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * High-level snapshot of market health used by dashboards and list views.
+ */
+public record MarketOverview(
+    String code,
+    String name,
+    String region,
+    String timezone,
+    String description,
+    double currentPrice,
+    double priceChangePercent,
+    double averagePrice,
+    double demandMw,
+    double renewablesShare,
+    double carbonIntensity,
+    double typicalPrice,
+    Instant lastUpdated) {
+
+  public MarketOverview {
+    Objects.requireNonNull(code, "code");
+    Objects.requireNonNull(name, "name");
+    Objects.requireNonNull(region, "region");
+    Objects.requireNonNull(timezone, "timezone");
+    Objects.requireNonNull(description, "description");
+    Objects.requireNonNull(lastUpdated, "lastUpdated");
+  }
+}

--- a/backend/src/main/java/com/energymarket/market/model/MarketSnapshot.java
+++ b/backend/src/main/java/com/energymarket/market/model/MarketSnapshot.java
@@ -1,0 +1,21 @@
+package com.energymarket.market.model;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Composite response bundling the key datasets required by the dashboard.
+ */
+public record MarketSnapshot(
+    MarketOverview overview,
+    List<PricePoint> priceSeries,
+    List<ForecastPoint> forecast,
+    MarketInsights insights) {
+
+  public MarketSnapshot {
+    Objects.requireNonNull(overview, "overview");
+    Objects.requireNonNull(insights, "insights");
+    priceSeries = List.copyOf(priceSeries);
+    forecast = List.copyOf(forecast);
+  }
+}

--- a/backend/src/main/java/com/energymarket/market/model/PricePoint.java
+++ b/backend/src/main/java/com/energymarket/market/model/PricePoint.java
@@ -1,0 +1,19 @@
+package com.energymarket.market.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Represents a single historical measurement of the market.
+ */
+public record PricePoint(
+    Instant timestamp,
+    double priceMwh,
+    double demandMw,
+    double carbonIntensity,
+    double renewablesShare) {
+
+  public PricePoint {
+    Objects.requireNonNull(timestamp, "timestamp");
+  }
+}

--- a/backend/src/main/java/com/energymarket/market/service/MarketDataService.java
+++ b/backend/src/main/java/com/energymarket/market/service/MarketDataService.java
@@ -1,0 +1,124 @@
+package com.energymarket.market.service;
+
+import com.energymarket.market.MarketCode;
+import com.energymarket.market.exception.MarketNotFoundException;
+import com.energymarket.market.generator.MarketDataGenerator;
+import com.energymarket.market.model.MarketMetadata;
+import com.energymarket.market.model.MarketOverview;
+import com.energymarket.market.model.MarketSnapshot;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+/**
+ * Application service orchestrating synthetic data generation for API consumers.
+ */
+@Service
+public class MarketDataService {
+
+  private static final Duration OVERVIEW_HISTORY_RANGE = Duration.ofHours(24);
+  private static final Duration OVERVIEW_HISTORY_INTERVAL = Duration.ofMinutes(15);
+
+  private final Clock clock;
+  private final MarketDataGenerator generator;
+
+  public MarketDataService(Clock clock) {
+    this(clock, new MarketDataGenerator());
+  }
+
+  MarketDataService(Clock clock, MarketDataGenerator generator) {
+    this.clock = Objects.requireNonNull(clock, "clock");
+    this.generator = Objects.requireNonNull(generator, "generator");
+  }
+
+  /**
+   * Returns metadata for the supported markets.
+   */
+  public List<MarketMetadata> getMarketCatalog() {
+    return Arrays.stream(MarketCode.values())
+        .map(MarketCode::toMetadata)
+        .sorted((left, right) -> left.name().compareToIgnoreCase(right.name()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Returns high-level overviews for every market.
+   */
+  public List<MarketOverview> getMarketOverview() {
+    Instant now = clock.instant();
+    return Arrays.stream(MarketCode.values())
+        .map(code -> generator.generateOverview(code, now, OVERVIEW_HISTORY_RANGE, OVERVIEW_HISTORY_INTERVAL))
+        .sorted((left, right) -> left.name().compareToIgnoreCase(right.name()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Builds a detailed market snapshot used by the dashboard.
+   *
+   * @param marketCode requested market identifier
+   * @param historyHours number of hours of history to include (1-168)
+   * @param historyResolutionMinutes resolution of the history in minutes (5-180)
+   * @param forecastHours forecast horizon in hours (1-72)
+   * @param forecastResolutionMinutes forecast sampling in minutes (15-240)
+   * @return generated market snapshot
+   */
+  public MarketSnapshot getMarketSnapshot(
+      String marketCode,
+      int historyHours,
+      int historyResolutionMinutes,
+      int forecastHours,
+      int forecastResolutionMinutes) {
+    MarketCode market =
+        MarketCode.fromCode(marketCode)
+            .orElseThrow(() -> new MarketNotFoundException(marketCode));
+
+    Duration historyRange = toDurationHours(historyHours, 1, 168, "historyHours");
+    Duration historyInterval = toDurationMinutes(historyResolutionMinutes, 5, 180, "historyResolutionMinutes");
+    ensureDivisible(historyRange, historyInterval, "history range", "history interval");
+
+    Duration forecastRange = toDurationHours(forecastHours, 1, 72, "forecastHours");
+    Duration forecastInterval = toDurationMinutes(forecastResolutionMinutes, 15, 240, "forecastResolutionMinutes");
+    ensureDivisible(forecastRange, forecastInterval, "forecast range", "forecast interval");
+
+    Instant now = clock.instant();
+    return generator.generateSnapshot(market, now, historyRange, historyInterval, forecastRange, forecastInterval);
+  }
+
+  private Duration toDurationHours(int value, int minInclusive, int maxInclusive, String field) {
+    if (value < minInclusive || value > maxInclusive) {
+      throw new IllegalArgumentException(
+          String.format(
+              Locale.US,
+              "%s must be between %d and %d hours",
+              field,
+              minInclusive,
+              maxInclusive));
+    }
+    return Duration.ofHours(value);
+  }
+
+  private Duration toDurationMinutes(int value, int minInclusive, int maxInclusive, String field) {
+    if (value < minInclusive || value > maxInclusive) {
+      throw new IllegalArgumentException(
+          String.format(
+              Locale.US,
+              "%s must be between %d and %d minutes",
+              field,
+              minInclusive,
+              maxInclusive));
+    }
+    return Duration.ofMinutes(value);
+  }
+
+  private void ensureDivisible(Duration range, Duration interval, String rangeName, String intervalName) {
+    if (range.toMinutes() % interval.toMinutes() != 0) {
+      throw new IllegalArgumentException(rangeName + " must be evenly divisible by " + intervalName);
+    }
+  }
+}

--- a/backend/src/test/java/com/energymarket/market/api/MarketControllerTest.java
+++ b/backend/src/test/java/com/energymarket/market/api/MarketControllerTest.java
@@ -1,0 +1,92 @@
+package com.energymarket.market.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.energymarket.market.generator.MarketDataGenerator;
+import com.energymarket.market.model.MarketMetadata;
+import com.energymarket.market.service.MarketDataService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+class MarketControllerTest {
+
+  private WebTestClient webTestClient;
+
+  @BeforeEach
+  void setUp() {
+    Clock clock = Clock.fixed(Instant.parse("2025-01-15T12:00:00Z"), ZoneOffset.UTC);
+    MarketDataService service = new MarketDataService(clock, new MarketDataGenerator());
+    MarketController controller = new MarketController(service);
+    this.webTestClient =
+        WebTestClient.bindToController(controller)
+            .controllerAdvice(new ApiExceptionHandler())
+            .configureClient()
+            .baseUrl("/api/markets")
+            .build();
+  }
+
+  @Test
+  void shouldReturnMarketCatalog() {
+    webTestClient
+        .get()
+        .uri("/catalog")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBodyList(MarketMetadata.class)
+        .value(
+            list -> {
+              assertThat(list).isNotEmpty();
+              assertThat(list).extracting(MarketMetadata::code).contains("NEISO");
+            });
+  }
+
+  @Test
+  void shouldReturnSnapshot() {
+    webTestClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder
+                    .path("/NEISO/snapshot")
+                    .queryParam("historyHours", 24)
+                    .queryParam("historyResolutionMinutes", 15)
+                    .queryParam("forecastHours", 12)
+                    .queryParam("forecastResolutionMinutes", 60)
+                    .build())
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .jsonPath("$.overview.code")
+        .isEqualTo("NEISO")
+        .jsonPath("$.priceSeries.length()")
+        .isEqualTo(97)
+        .jsonPath("$.forecast.length()")
+        .isEqualTo(12)
+        .jsonPath("$.insights.alerts")
+        .isArray();
+  }
+
+  @Test
+  void shouldReturnNotFoundForUnknownMarket() {
+    webTestClient
+        .get()
+        .uri("/UNKNOWN/snapshot")
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectBody()
+        .jsonPath("$.title")
+        .isEqualTo("Market not found");
+  }
+}

--- a/backend/src/test/java/com/energymarket/market/service/MarketDataServiceTest.java
+++ b/backend/src/test/java/com/energymarket/market/service/MarketDataServiceTest.java
@@ -1,0 +1,77 @@
+package com.energymarket.market.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.energymarket.market.exception.MarketNotFoundException;
+import com.energymarket.market.generator.MarketDataGenerator;
+import com.energymarket.market.model.MarketMetadata;
+import com.energymarket.market.model.MarketSnapshot;
+import com.energymarket.market.model.PricePoint;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MarketDataServiceTest {
+
+  private MarketDataService service;
+
+  @BeforeEach
+  void setUp() {
+    Clock fixedClock = Clock.fixed(Instant.parse("2025-01-15T12:00:00Z"), ZoneOffset.UTC);
+    service = new MarketDataService(fixedClock, new MarketDataGenerator());
+  }
+
+  @Test
+  void shouldGenerateConsistentSnapshot() {
+    MarketSnapshot snapshot = service.getMarketSnapshot("NEISO", 24, 15, 12, 60);
+
+    assertThat(snapshot.overview().code()).isEqualTo("NEISO");
+    assertThat(snapshot.priceSeries())
+        .hasSize(97)
+        .isSortedAccordingTo(Comparator.comparing(PricePoint::timestamp))
+        .allSatisfy(
+            point -> {
+              assertThat(point.priceMwh()).isGreaterThan(0.0);
+              assertThat(point.demandMw()).isGreaterThan(0.0);
+              assertThat(point.renewablesShare()).isBetween(0.0, 100.0);
+            });
+    assertThat(snapshot.forecast()).hasSize(12);
+    assertThat(snapshot.insights().alerts()).isNotNull();
+  }
+
+  @Test
+  void shouldRejectInvalidHistoryResolution() {
+    assertThatThrownBy(() -> service.getMarketSnapshot("NEISO", 24, 4, 12, 60))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("historyResolutionMinutes");
+  }
+
+  @Test
+  void shouldRejectInvalidForecastResolution() {
+    assertThatThrownBy(() -> service.getMarketSnapshot("NEISO", 24, 15, 12, 10))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("forecastResolutionMinutes");
+  }
+
+  @Test
+  void shouldRejectUnknownMarketCode() {
+    assertThatThrownBy(() -> service.getMarketSnapshot("UNKNOWN", 24, 15, 12, 60))
+        .isInstanceOf(MarketNotFoundException.class)
+        .hasMessageContaining("Unknown market code");
+  }
+
+  @Test
+  void shouldListCatalogSortedByName() {
+    List<MarketMetadata> catalog = service.getMarketCatalog();
+
+    assertThat(catalog).isNotEmpty();
+    assertThat(catalog)
+        .isSortedAccordingTo(Comparator.comparing(MarketMetadata::name, String.CASE_INSENSITIVE_ORDER));
+    assertThat(catalog).extracting(MarketMetadata::code).contains("NEISO", "ERCOT");
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,31 +1,221 @@
-import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
 
+const mockCatalog = [
+  {
+    code: 'NEISO',
+    name: 'ISO New England Hub',
+    region: 'New England',
+    timezone: 'America/New_York',
+    description: 'Tight reserve margins and winter risk.',
+    typicalPrice: 85,
+  },
+  {
+    code: 'ERCOT',
+    name: 'ERCOT Real-Time Hub',
+    region: 'Texas',
+    timezone: 'America/Chicago',
+    description: 'Weather-sensitive grid.',
+    typicalPrice: 72,
+  },
+];
+
+const mockOverview = [
+  {
+    code: 'NEISO',
+    name: 'ISO New England Hub',
+    region: 'New England',
+    timezone: 'America/New_York',
+    description: 'Tight reserve margins and winter risk.',
+    typicalPrice: 85,
+    currentPrice: 88.2,
+    priceChangePercent: 3.5,
+    averagePrice: 82.1,
+    demandMw: 18500,
+    renewablesShare: 52.4,
+    carbonIntensity: 290.2,
+    lastUpdated: '2025-01-15T12:00:00Z',
+  },
+  {
+    code: 'ERCOT',
+    name: 'ERCOT Real-Time Hub',
+    region: 'Texas',
+    timezone: 'America/Chicago',
+    description: 'Weather-sensitive grid.',
+    typicalPrice: 72,
+    currentPrice: 64.3,
+    priceChangePercent: -1.2,
+    averagePrice: 66.8,
+    demandMw: 52000,
+    renewablesShare: 34.7,
+    carbonIntensity: 410.4,
+    lastUpdated: '2025-01-15T12:00:00Z',
+  },
+];
+
+const mockSnapshot = {
+  overview: {
+    code: 'NEISO',
+    name: 'ISO New England Hub',
+    region: 'New England',
+    timezone: 'America/New_York',
+    description: 'Tight reserve margins and winter risk.',
+    typicalPrice: 85,
+    currentPrice: 88.2,
+    priceChangePercent: 3.5,
+    averagePrice: 82.1,
+    demandMw: 18500,
+    renewablesShare: 52.4,
+    carbonIntensity: 290.2,
+    lastUpdated: '2025-01-15T12:00:00Z',
+  },
+  priceSeries: [
+    {
+      timestamp: '2025-01-15T08:00:00Z',
+      priceMwh: 80.2,
+      demandMw: 15000,
+      carbonIntensity: 300,
+      renewablesShare: 48,
+    },
+    {
+      timestamp: '2025-01-15T09:00:00Z',
+      priceMwh: 82.5,
+      demandMw: 15850,
+      carbonIntensity: 298,
+      renewablesShare: 49,
+    },
+    {
+      timestamp: '2025-01-15T10:00:00Z',
+      priceMwh: 85.1,
+      demandMw: 16600,
+      carbonIntensity: 295,
+      renewablesShare: 50,
+    },
+    {
+      timestamp: '2025-01-15T11:00:00Z',
+      priceMwh: 87.3,
+      demandMw: 17250,
+      carbonIntensity: 292,
+      renewablesShare: 51,
+    },
+    {
+      timestamp: '2025-01-15T12:00:00Z',
+      priceMwh: 88.2,
+      demandMw: 18500,
+      carbonIntensity: 290,
+      renewablesShare: 52.4,
+    },
+  ],
+  forecast: [
+    {
+      timestamp: '2025-01-15T13:00:00Z',
+      projectedPriceMwh: 90.1,
+      lowerBound: 85.2,
+      upperBound: 95.4,
+    },
+    {
+      timestamp: '2025-01-15T14:00:00Z',
+      projectedPriceMwh: 91.2,
+      lowerBound: 86.1,
+      upperBound: 96.8,
+    },
+    {
+      timestamp: '2025-01-15T15:00:00Z',
+      projectedPriceMwh: 92.5,
+      lowerBound: 87.4,
+      upperBound: 98.3,
+    },
+    {
+      timestamp: '2025-01-15T16:00:00Z',
+      projectedPriceMwh: 93.1,
+      lowerBound: 88.0,
+      upperBound: 99.2,
+    },
+  ],
+  insights: {
+    windowStart: '2025-01-15T08:00:00Z',
+    windowEnd: '2025-01-15T12:00:00Z',
+    averagePrice: 84.7,
+    priceStandardDeviation: 3.1,
+    minPrice: 80.2,
+    maxPrice: 88.2,
+    averageDemand: 16640,
+    peakDemand: 18500,
+    averageRenewablesShare: 50.5,
+    carbonIntensityTrendPerHour: -1.2,
+    alerts: [
+      'Price spike detected: +4.1% vs average',
+      'Renewable output is significantly below typical levels',
+    ],
+  },
+};
+
 describe('App Component', () => {
-  it('renders the main heading', () => {
-    render(<App />);
-
-    const heading = screen.getByRole('heading', { level: 1 });
-    expect(heading).toBeInTheDocument();
-    expect(heading).toHaveTextContent('Energy Market Visualization');
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : input.toString();
+      if (url.endsWith('/api/markets/catalog')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(mockCatalog), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      if (url.endsWith('/api/markets/overview')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(mockOverview), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      if (url.includes('/api/markets/NEISO/snapshot')) {
+        return Promise.resolve(
+          new Response(JSON.stringify(mockSnapshot), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.reject(new Error(`Unhandled request: ${url}`));
+    });
   });
 
-  it('displays the coming soon message', () => {
-    render(<App />);
-
-    const message = screen.getByText(/premium energy market data visualization coming soon/i);
-    expect(message).toBeInTheDocument();
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('has proper semantic structure', () => {
-    render(<App />);
+  const renderApp = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
 
-    // Check for proper semantic elements
-    expect(screen.getByRole('banner')).toBeInTheDocument(); // header
-    expect(screen.getByRole('main')).toBeInTheDocument(); // main
-    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument(); // h1
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>,
+    );
+  };
+
+  it('renders the intelligence dashboard with loaded data', async () => {
+    renderApp();
+
+    expect(await screen.findByText('Energy Market Intelligence Console')).toBeInTheDocument();
+    expect(await screen.findByText('ISO New England Hub')).toBeInTheDocument();
+    expect(await screen.findByText('$88.20')).toBeInTheDocument();
+
+    const chart = await screen.findByTestId('mock-line-chart');
+    expect(chart).toHaveAttribute('data-point-count', '5');
+
+    expect(await screen.findByText('Forward price envelope')).toBeInTheDocument();
+    expect(await screen.findByText('Projected Price')).toBeInTheDocument();
+    expect(await screen.findByText('Price spike detected: +4.1% vs average')).toBeInTheDocument();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,26 +1,112 @@
-import React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import DashboardHeader from '@/components/DashboardHeader';
+import ErrorState from '@/components/ErrorState';
+import ForecastTable from '@/components/ForecastTable';
+import InsightsPanel from '@/components/InsightsPanel';
+import LoadingState from '@/components/LoadingState';
+import MarketSummaryGrid from '@/components/MarketSummaryGrid';
+import PriceChart from '@/components/PriceChart';
+import { useMarketCatalog, useMarketOverview, useMarketSnapshot } from '@/api/hooks';
 
-/**
- * Main App component for Energy Market Visualization.
- *
- * @returns JSX element representing the main application
- */
-const App: React.FC = (): JSX.Element => {
+const App = (): JSX.Element => {
+  const { data: catalog, isLoading: catalogLoading, isError: catalogError, refetch: refetchCatalog } =
+    useMarketCatalog();
+  const {
+    data: overview,
+    isLoading: overviewLoading,
+    isError: overviewError,
+    isFetching: overviewFetching,
+    refetch: refetchOverview,
+  } = useMarketOverview();
+
+  const [selectedMarket, setSelectedMarket] = useState<string>();
+  const [historyHours, setHistoryHours] = useState(24);
+  const [historyResolutionMinutes, setHistoryResolutionMinutes] = useState(15);
+  const [forecastHours, setForecastHours] = useState(12);
+  const forecastResolutionMinutes = 60;
+
+  useEffect(() => {
+    if (!selectedMarket && catalog && catalog.length > 0) {
+      setSelectedMarket(catalog[0].code);
+    }
+  }, [catalog, selectedMarket]);
+
+  const snapshotParams = useMemo(
+    () => ({
+      historyHours,
+      historyResolutionMinutes,
+      forecastHours,
+      forecastResolutionMinutes,
+    }),
+    [historyHours, historyResolutionMinutes, forecastHours, forecastResolutionMinutes],
+  );
+
+  const {
+    data: snapshot,
+    isLoading: snapshotLoading,
+    isError: snapshotError,
+    isFetching: snapshotFetching,
+    refetch: refetchSnapshot,
+  } = useMarketSnapshot(selectedMarket, snapshotParams);
+
+  const isLoading = catalogLoading || overviewLoading || snapshotLoading || !selectedMarket;
+  const hasError = catalogError || overviewError || snapshotError;
+
+  const handleRefresh = () => {
+    void refetchCatalog();
+    void refetchOverview();
+    void refetchSnapshot();
+  };
+
+  if (hasError) {
+    return <ErrorState onRetry={handleRefresh} />;
+  }
+
+  if (isLoading || !catalog || !overview || !snapshot || !selectedMarket) {
+    return <LoadingState />;
+  }
+
+  const isRefreshing = snapshotFetching || overviewFetching;
+
   return (
-    <div className='min-h-screen bg-gray-50'>
-      <header className='bg-white shadow'>
-        <div className='max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8'>
-          <h1 className='text-3xl font-bold text-gray-900'>Energy Market Visualization</h1>
-        </div>
-      </header>
-      <main className='max-w-7xl mx-auto py-6 sm:px-6 lg:px-8'>
-        <div className='px-4 py-6 sm:px-0'>
-          <div className='border-4 border-dashed border-gray-200 rounded-lg h-96 flex items-center justify-center'>
-            <p className='text-lg text-gray-500'>
-              Premium energy market data visualization coming soon...
-            </p>
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <DashboardHeader
+        markets={catalog}
+        selectedMarket={selectedMarket}
+        onSelectMarket={setSelectedMarket}
+        lastUpdated={snapshot.overview.lastUpdated}
+        isRefreshing={isRefreshing}
+        historyHours={historyHours}
+        onHistoryHoursChange={setHistoryHours}
+        historyResolutionMinutes={historyResolutionMinutes}
+        onHistoryResolutionChange={setHistoryResolutionMinutes}
+        forecastHours={forecastHours}
+        onForecastHoursChange={setForecastHours}
+        onRefresh={handleRefresh}
+      />
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 py-8">
+        <section>
+          <h2 className="text-xl font-semibold text-slate-200">Market overview</h2>
+          <p className="text-sm text-slate-400">
+            Select a market to explore intraday fundamentals, price formation and forecasted risk.
+          </p>
+          <MarketSummaryGrid
+            overviews={overview}
+            selectedMarket={selectedMarket}
+            onSelectMarket={setSelectedMarket}
+          />
+        </section>
+        <section className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <div className="rounded-2xl border border-slate-800/80 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40 lg:col-span-2">
+            <PriceChart priceSeries={snapshot.priceSeries} selectedMarketName={snapshot.overview.name} />
           </div>
-        </div>
+          <div className="rounded-2xl border border-slate-800/80 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+            <ForecastTable forecast={snapshot.forecast} />
+          </div>
+        </section>
+        <section className="rounded-2xl border border-slate-800/80 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+          <InsightsPanel insights={snapshot.insights} marketName={snapshot.overview.name} />
+        </section>
       </main>
     </div>
   );

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,53 @@
+import type {
+  MarketMetadata,
+  MarketOverview,
+  MarketSnapshot,
+  SnapshotRequestParams,
+} from '@/types/api';
+
+const DEFAULT_HEADERS: HeadersInit = {
+  Accept: 'application/json',
+};
+
+async function fetchJson<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    ...init,
+    headers: {
+      ...DEFAULT_HEADERS,
+      ...init?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(
+      `Request failed with status ${response.status}: ${message || response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+export function getMarketCatalog(): Promise<MarketMetadata[]> {
+  return fetchJson<MarketMetadata[]>('/api/markets/catalog');
+}
+
+export function getMarketOverview(): Promise<MarketOverview[]> {
+  return fetchJson<MarketOverview[]>('/api/markets/overview');
+}
+
+export function getMarketSnapshot(
+  marketCode: string,
+  params: SnapshotRequestParams,
+): Promise<MarketSnapshot> {
+  const searchParams = new URLSearchParams({
+    historyHours: params.historyHours.toString(),
+    historyResolutionMinutes: params.historyResolutionMinutes.toString(),
+    forecastHours: params.forecastHours.toString(),
+    forecastResolutionMinutes: params.forecastResolutionMinutes.toString(),
+  });
+
+  return fetchJson<MarketSnapshot>(
+    `/api/markets/${encodeURIComponent(marketCode)}/snapshot?${searchParams.toString()}`,
+  );
+}

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -1,0 +1,54 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { getMarketCatalog, getMarketOverview, getMarketSnapshot } from '@/api/client';
+import type { SnapshotRequestParams } from '@/types/api';
+
+const CATALOG_QUERY_KEY = ['markets', 'catalog'] as const;
+const OVERVIEW_QUERY_KEY = ['markets', 'overview'] as const;
+
+function snapshotQueryKey(marketCode: string | undefined, params: SnapshotRequestParams) {
+  return [
+    'markets',
+    'snapshot',
+    marketCode ?? 'unknown',
+    params.historyHours,
+    params.historyResolutionMinutes,
+    params.forecastHours,
+    params.forecastResolutionMinutes,
+  ] as const;
+}
+
+export function useMarketCatalog() {
+  return useQuery({
+    queryKey: CATALOG_QUERY_KEY,
+    queryFn: getMarketCatalog,
+    staleTime: 10 * 60 * 1000,
+  });
+}
+
+export function useMarketOverview() {
+  return useQuery({
+    queryKey: OVERVIEW_QUERY_KEY,
+    queryFn: getMarketOverview,
+    staleTime: 30 * 1000,
+    refetchInterval: 60 * 1000,
+  });
+}
+
+export function useMarketSnapshot(
+  marketCode: string | undefined,
+  params: SnapshotRequestParams,
+) {
+  return useQuery({
+    queryKey: snapshotQueryKey(marketCode, params),
+    queryFn: () => {
+      if (!marketCode) {
+        throw new Error('A market code is required to fetch a snapshot');
+      }
+      return getMarketSnapshot(marketCode, params);
+    },
+    enabled: Boolean(marketCode),
+    staleTime: 30 * 1000,
+    refetchInterval: 60 * 1000,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/frontend/src/components/DashboardHeader.tsx
+++ b/frontend/src/components/DashboardHeader.tsx
@@ -1,0 +1,144 @@
+import type { FC } from 'react';
+import type { MarketMetadata } from '@/types/api';
+import { formatDateTime } from '@/utils/format';
+
+interface DashboardHeaderProps {
+  markets: MarketMetadata[];
+  selectedMarket: string;
+  onSelectMarket: (marketCode: string) => void;
+  lastUpdated: string;
+  isRefreshing: boolean;
+  historyHours: number;
+  onHistoryHoursChange: (value: number) => void;
+  historyResolutionMinutes: number;
+  onHistoryResolutionChange: (value: number) => void;
+  forecastHours: number;
+  onForecastHoursChange: (value: number) => void;
+  onRefresh: () => void;
+}
+
+const HISTORY_OPTIONS = [24, 48, 72, 168];
+const HISTORY_RESOLUTION_OPTIONS = [15, 30, 60];
+const FORECAST_OPTIONS = [12, 24, 36];
+
+const selectClassName =
+  'mt-1 rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-100 shadow-inner shadow-slate-900 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60';
+
+export const DashboardHeader: FC<DashboardHeaderProps> = ({
+  markets,
+  selectedMarket,
+  onSelectMarket,
+  lastUpdated,
+  isRefreshing,
+  historyHours,
+  onHistoryHoursChange,
+  historyResolutionMinutes,
+  onHistoryResolutionChange,
+  forecastHours,
+  onForecastHoursChange,
+  onRefresh,
+}) => {
+  return (
+    <header className="border-b border-slate-800 bg-slate-900/95">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 py-6 md:flex-row md:items-end md:justify-between">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold text-white">Energy Market Intelligence Console</h1>
+          <p className="text-sm text-slate-400">
+            Live synthetic telemetry highlighting price formation, demand pressure, and grid health.
+          </p>
+          <p className="text-xs uppercase tracking-wide text-slate-500">
+            Last updated {formatDateTime(lastUpdated)}
+            {isRefreshing ? ' • refreshing…' : ''}
+          </p>
+        </div>
+        <div className="flex w-full flex-col gap-4 md:w-auto md:flex-row md:items-end">
+          <div className="flex flex-1 flex-col md:flex-none">
+            <label htmlFor="market" className="text-xs font-semibold uppercase text-slate-400">
+              Market
+            </label>
+            <select
+              id="market"
+              value={selectedMarket}
+              onChange={(event) => onSelectMarket(event.target.value)}
+              className={selectClassName}
+            >
+              {markets.map((market) => (
+                <option key={market.code} value={market.code}>
+                  {market.name}
+                </option>
+              ))}
+            </select>
+            <p className="mt-1 text-[11px] text-slate-500">
+              {markets.find((market) => market.code === selectedMarket)?.description}
+            </p>
+          </div>
+          <div className="grid flex-1 grid-cols-2 gap-4 md:flex-none md:grid-cols-3">
+            <div className="flex flex-col">
+              <label htmlFor="history-hours" className="text-xs font-semibold uppercase text-slate-400">
+                History
+              </label>
+              <select
+                id="history-hours"
+                value={historyHours}
+                onChange={(event) => onHistoryHoursChange(Number(event.target.value))}
+                className={selectClassName}
+              >
+                {HISTORY_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}h
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col">
+              <label
+                htmlFor="history-resolution"
+                className="text-xs font-semibold uppercase text-slate-400"
+              >
+                Resolution
+              </label>
+              <select
+                id="history-resolution"
+                value={historyResolutionMinutes}
+                onChange={(event) => onHistoryResolutionChange(Number(event.target.value))}
+                className={selectClassName}
+              >
+                {HISTORY_RESOLUTION_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}m
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor="forecast-hours" className="text-xs font-semibold uppercase text-slate-400">
+                Forecast
+              </label>
+              <select
+                id="forecast-hours"
+                value={forecastHours}
+                onChange={(event) => onForecastHoursChange(Number(event.target.value))}
+                className={selectClassName}
+              >
+                {FORECAST_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}h
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onRefresh}
+            className="inline-flex items-center justify-center rounded-lg border border-sky-500/80 bg-sky-500/10 px-4 py-2 text-sm font-semibold text-sky-300 transition hover:bg-sky-500/20 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+          >
+            Refresh data
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default DashboardHeader;

--- a/frontend/src/components/ErrorState.tsx
+++ b/frontend/src/components/ErrorState.tsx
@@ -1,0 +1,30 @@
+import type { FC } from 'react';
+
+interface ErrorStateProps {
+  onRetry?: () => void;
+}
+
+const ErrorState: FC<ErrorStateProps> = ({ onRetry }) => {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-200">
+      <div className="max-w-md space-y-4 text-center">
+        <h2 className="text-2xl font-semibold text-rose-300">We lost the market feed</h2>
+        <p className="text-sm text-slate-400">
+          The intelligence service could not load the latest curves. Please verify the backend is
+          running and try again.
+        </p>
+        {onRetry ? (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex items-center justify-center rounded-lg border border-rose-400/60 bg-rose-400/10 px-4 py-2 text-sm font-semibold text-rose-200 transition hover:bg-rose-400/20"
+          >
+            Retry request
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default ErrorState;

--- a/frontend/src/components/ForecastTable.tsx
+++ b/frontend/src/components/ForecastTable.tsx
@@ -1,0 +1,67 @@
+import type { FC } from 'react';
+import type { ForecastPoint } from '@/types/api';
+import { formatPrice, formatTimeLabel } from '@/utils/format';
+
+interface ForecastTableProps {
+  forecast: ForecastPoint[];
+}
+
+const ForecastTable: FC<ForecastTableProps> = ({ forecast }) => {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold text-slate-100">Forward price envelope</h3>
+        <p className="text-xs text-slate-400">
+          Seasonal-aware projection with volatility-aware confidence bounds.
+        </p>
+      </div>
+      <div className="flex-1 overflow-hidden rounded-xl border border-slate-800/80">
+        <table className="min-w-full divide-y divide-slate-800 text-sm">
+          <thead className="bg-slate-900/70 text-xs uppercase tracking-wide text-slate-400">
+            <tr>
+              <th scope="col" className="px-4 py-3 text-left">
+                Interval
+              </th>
+              <th scope="col" className="px-4 py-3 text-right">
+                Projected Price
+              </th>
+              <th scope="col" className="px-4 py-3 text-right">
+                Lower Bound
+              </th>
+              <th scope="col" className="px-4 py-3 text-right">
+                Upper Bound
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/80 bg-slate-900/40 text-slate-200">
+            {forecast.map((point) => (
+              <tr key={point.timestamp}>
+                <td className="px-4 py-2 text-left font-medium text-slate-300">
+                  {formatTimeLabel(point.timestamp)}
+                </td>
+                <td className="px-4 py-2 text-right font-semibold text-sky-300">
+                  {formatPrice(point.projectedPriceMwh)}
+                </td>
+                <td className="px-4 py-2 text-right text-slate-300">
+                  {formatPrice(point.lowerBound)}
+                </td>
+                <td className="px-4 py-2 text-right text-slate-300">
+                  {formatPrice(point.upperBound)}
+                </td>
+              </tr>
+            ))}
+            {forecast.length === 0 ? (
+              <tr>
+                <td className="px-4 py-4 text-center text-slate-400" colSpan={4}>
+                  Forecast data not available for the selected configuration.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default ForecastTable;

--- a/frontend/src/components/InsightsPanel.tsx
+++ b/frontend/src/components/InsightsPanel.tsx
@@ -1,0 +1,105 @@
+import type { FC } from 'react';
+import type { MarketInsights } from '@/types/api';
+import {
+  formatDateTime,
+  formatMegawatts,
+  formatPrice,
+  formatRenewablesShare,
+  formatTrend,
+} from '@/utils/format';
+
+interface InsightsPanelProps {
+  insights: MarketInsights;
+  marketName: string;
+}
+
+const InsightsPanel: FC<InsightsPanelProps> = ({ insights, marketName }) => {
+  const metrics = [
+    {
+      label: 'Average Price',
+      value: formatPrice(insights.averagePrice),
+      description: 'Mean value across the selected history window.',
+    },
+    {
+      label: 'Volatility (σ)',
+      value: formatPrice(insights.priceStandardDeviation),
+      description: 'Standard deviation captures realised volatility.',
+    },
+    {
+      label: 'Price Range',
+      value: `${formatPrice(insights.minPrice)} – ${formatPrice(insights.maxPrice)}`,
+      description: 'Observed minimum and maximum price in the window.',
+    },
+    {
+      label: 'Average Demand',
+      value: formatMegawatts(insights.averageDemand),
+      description: 'Mean system load over the analysis horizon.',
+    },
+    {
+      label: 'Peak Demand',
+      value: formatMegawatts(insights.peakDemand),
+      description: 'Maximum observed load for the period.',
+    },
+    {
+      label: 'Renewable Share',
+      value: formatRenewablesShare(insights.averageRenewablesShare),
+      description: 'Average share of supply met by renewables.',
+    },
+    {
+      label: 'Carbon Trend',
+      value: `${formatTrend(insights.carbonIntensityTrendPerHour)}%/h`,
+      description: 'Directional slope of carbon intensity per hour.',
+    },
+  ];
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-3">
+      <div className="lg:col-span-2">
+        <div className="mb-4 flex flex-col gap-1">
+          <h3 className="text-lg font-semibold text-slate-100">Market quality metrics</h3>
+          <p className="text-xs text-slate-400">
+            Sampling window {formatDateTime(insights.windowStart)} → {formatDateTime(insights.windowEnd)}
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {metrics.map((metric) => (
+            <div
+              key={metric.label}
+              className="rounded-2xl border border-slate-800/80 bg-slate-900/50 p-4 shadow-inner shadow-slate-950/50"
+            >
+              <p className="text-xs uppercase tracking-wide text-slate-400">{metric.label}</p>
+              <p className="mt-1 text-xl font-semibold text-slate-100">{metric.value}</p>
+              <p className="mt-2 text-xs text-slate-500">{metric.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col">
+        <div className="mb-4">
+          <h3 className="text-lg font-semibold text-slate-100">Operational alerts</h3>
+          <p className="text-xs text-slate-400">
+            Prioritised signals for {marketName.toLowerCase()} traders and system operators.
+          </p>
+        </div>
+        <div className="flex-1 rounded-2xl border border-slate-800/80 bg-slate-900/40 p-4">
+          {insights.alerts.length > 0 ? (
+            <ul className="space-y-3 text-sm text-slate-200">
+              {insights.alerts.map((alert) => (
+                <li key={alert} className="flex items-start gap-3">
+                  <span className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full bg-amber-400" aria-hidden="true" />
+                  <span>{alert}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-slate-400">
+              No anomalies detected — market conditions remain within expected bands.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InsightsPanel;

--- a/frontend/src/components/LoadingState.tsx
+++ b/frontend/src/components/LoadingState.tsx
@@ -1,0 +1,15 @@
+const LoadingState = () => {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-300">
+      <div className="text-center">
+        <div className="mx-auto mb-4 h-10 w-10 animate-spin rounded-full border-2 border-sky-500 border-t-transparent" />
+        <h2 className="text-lg font-semibold">Streaming market intelligence…</h2>
+        <p className="mt-2 text-sm text-slate-400">
+          Building the price curve, balancing demand, and calibrating renewable signals.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default LoadingState;

--- a/frontend/src/components/MarketSummaryGrid.tsx
+++ b/frontend/src/components/MarketSummaryGrid.tsx
@@ -1,0 +1,86 @@
+import clsx from 'clsx';
+import type { FC } from 'react';
+import type { MarketOverview } from '@/types/api';
+import {
+  formatCarbonIntensity,
+  formatMegawatts,
+  formatPercent,
+  formatPrice,
+  formatRenewablesShare,
+} from '@/utils/format';
+
+interface MarketSummaryGridProps {
+  overviews: MarketOverview[];
+  selectedMarket: string;
+  onSelectMarket: (marketCode: string) => void;
+}
+
+const MarketSummaryGrid: FC<MarketSummaryGridProps> = ({
+  overviews,
+  selectedMarket,
+  onSelectMarket,
+}) => {
+  return (
+    <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {overviews.map((overview) => {
+        const isSelected = overview.code === selectedMarket;
+        return (
+          <button
+            key={overview.code}
+            type="button"
+            onClick={() => onSelectMarket(overview.code)}
+            aria-pressed={isSelected}
+            className={clsx(
+              'rounded-2xl border px-5 py-4 text-left transition shadow-lg shadow-slate-950/40',
+              isSelected
+                ? 'border-sky-500/80 bg-sky-500/10'
+                : 'border-slate-800/80 bg-slate-800/60 hover:border-sky-500/40 hover:bg-slate-800/80',
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-slate-100">{overview.name}</h3>
+                <p className="text-xs uppercase tracking-wide text-slate-400">{overview.region}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-2xl font-bold text-slate-100">{formatPrice(overview.currentPrice)}</p>
+                <p
+                  className={clsx(
+                    'text-sm font-semibold',
+                    overview.priceChangePercent >= 0 ? 'text-emerald-400' : 'text-rose-400',
+                  )}
+                >
+                  {formatPercent(overview.priceChangePercent, { showSign: true })}
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 grid grid-cols-2 gap-4 text-sm text-slate-300">
+              <div>
+                <p className="text-xs uppercase text-slate-400">Avg Price</p>
+                <p className="font-semibold text-slate-100">{formatPrice(overview.averagePrice)}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-slate-400">Demand</p>
+                <p className="font-semibold text-slate-100">{formatMegawatts(overview.demandMw)}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-slate-400">Renewables</p>
+                <p className="font-semibold text-emerald-300">
+                  {formatRenewablesShare(overview.renewablesShare)}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-slate-400">Carbon Intensity</p>
+                <p className="font-semibold text-amber-200">
+                  {formatCarbonIntensity(overview.carbonIntensity)}
+                </p>
+              </div>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MarketSummaryGrid;

--- a/frontend/src/components/PriceChart.tsx
+++ b/frontend/src/components/PriceChart.tsx
@@ -1,0 +1,135 @@
+import { useMemo } from 'react';
+import type { FC } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Filler,
+  Legend,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Tooltip,
+  type ChartData,
+  type ChartOptions,
+} from 'chart.js';
+import type { PricePoint } from '@/types/api';
+import { formatTimeLabel } from '@/utils/format';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, Tooltip, Legend);
+
+interface PriceChartProps {
+  priceSeries: PricePoint[];
+  selectedMarketName: string;
+}
+
+const PriceChart: FC<PriceChartProps> = ({ priceSeries, selectedMarketName }) => {
+  const chartData = useMemo<ChartData<'line'>>(() => {
+    if (priceSeries.length === 0) {
+      return { labels: [], datasets: [] };
+    }
+
+    const labels = priceSeries.map((point) => formatTimeLabel(point.timestamp));
+
+    return {
+      labels,
+      datasets: [
+        {
+          label: `${selectedMarketName} price ($/MWh)`,
+          data: priceSeries.map((point) => Number(point.priceMwh.toFixed(2))),
+          borderColor: '#38bdf8',
+          backgroundColor: 'rgba(56, 189, 248, 0.2)',
+          fill: true,
+          tension: 0.35,
+          pointRadius: 0,
+          borderWidth: 2,
+          yAxisID: 'y',
+        },
+        {
+          label: 'Demand (MW)',
+          data: priceSeries.map((point) => Number(point.demandMw.toFixed(0))),
+          borderColor: '#34d399',
+          backgroundColor: 'rgba(52, 211, 153, 0.12)',
+          fill: true,
+          tension: 0.35,
+          pointRadius: 0,
+          borderWidth: 2,
+          yAxisID: 'y1',
+        },
+      ],
+    };
+  }, [priceSeries, selectedMarketName]);
+
+  const options = useMemo<ChartOptions<'line'>>(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          labels: {
+            color: '#e2e8f0',
+            boxWidth: 16,
+          },
+        },
+        tooltip: {
+          mode: 'index',
+          intersect: false,
+        },
+      },
+      interaction: {
+        mode: 'index',
+        intersect: false,
+      },
+      scales: {
+        x: {
+          ticks: {
+            color: '#94a3b8',
+            maxRotation: 0,
+            autoSkip: true,
+            maxTicksLimit: 10,
+          },
+          grid: {
+            color: 'rgba(148, 163, 184, 0.12)',
+          },
+        },
+        y: {
+          position: 'left',
+          ticks: {
+            color: '#cbd5f5',
+            callback: (value) => `$${value}`,
+          },
+          grid: {
+            color: 'rgba(148, 163, 184, 0.08)',
+          },
+        },
+        y1: {
+          position: 'right',
+          ticks: {
+            color: '#cbd5f5',
+            callback: (value) => `${value} MW`,
+          },
+          grid: {
+            drawOnChartArea: false,
+          },
+        },
+      },
+    }),
+    [],
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-100">Price &amp; demand dynamics</h3>
+          <p className="text-xs text-slate-400">{selectedMarketName}</p>
+        </div>
+      </div>
+      <div className="flex-1">
+        <Line data={chartData} options={options} />
+      </div>
+    </div>
+  );
+};
+
+export default PriceChart;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-950 text-slate-100 antialiased;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
+import './index.css';
 
-/**
- * Application entry point - renders the main App component.
- */
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30 * 1000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});
+
 const rootElement = document.getElementById('root');
 
 if (rootElement === null) {
@@ -16,6 +24,8 @@ const root = ReactDOM.createRoot(rootElement);
 
 root.render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>,
 );

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,13 @@
 import '@testing-library/jest-dom';
+import React from 'react';
+import type { ChartData } from 'chart.js';
+import { vi } from 'vitest';
+
+vi.mock('react-chartjs-2', () => ({
+  Line: ({ data }: { data: ChartData<'line'> }) => (
+    <div
+      data-testid="mock-line-chart"
+      data-point-count={String(data.datasets?.[0]?.data?.length ?? 0)}
+    />
+  ),
+}));

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,61 @@
+export interface MarketMetadata {
+  code: string;
+  name: string;
+  region: string;
+  timezone: string;
+  description: string;
+  typicalPrice: number;
+}
+
+export interface MarketOverview extends MarketMetadata {
+  currentPrice: number;
+  priceChangePercent: number;
+  averagePrice: number;
+  demandMw: number;
+  renewablesShare: number;
+  carbonIntensity: number;
+  lastUpdated: string;
+}
+
+export interface PricePoint {
+  timestamp: string;
+  priceMwh: number;
+  demandMw: number;
+  carbonIntensity: number;
+  renewablesShare: number;
+}
+
+export interface ForecastPoint {
+  timestamp: string;
+  projectedPriceMwh: number;
+  lowerBound: number;
+  upperBound: number;
+}
+
+export interface MarketInsights {
+  windowStart: string;
+  windowEnd: string;
+  averagePrice: number;
+  priceStandardDeviation: number;
+  minPrice: number;
+  maxPrice: number;
+  averageDemand: number;
+  peakDemand: number;
+  averageRenewablesShare: number;
+  carbonIntensityTrendPerHour: number;
+  alerts: string[];
+}
+
+export interface MarketSnapshot {
+  overview: MarketOverview;
+  priceSeries: PricePoint[];
+  forecast: ForecastPoint[];
+  insights: MarketInsights;
+}
+
+export interface SnapshotRequestParams {
+  historyHours: number;
+  historyResolutionMinutes: number;
+  forecastHours: number;
+  forecastResolutionMinutes: number;
+}

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,67 @@
+const priceFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 2,
+});
+
+const wholeNumberFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0,
+});
+
+const decimalFormatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+const dateTimeFormatter = new Intl.DateTimeFormat('en-US', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+const timeFormatter = new Intl.DateTimeFormat('en-US', {
+  hour: 'numeric',
+  minute: '2-digit',
+});
+
+export function formatPrice(value: number): string {
+  return priceFormatter.format(value);
+}
+
+export function formatMegawatts(value: number): string {
+  return `${wholeNumberFormatter.format(value)} MW`;
+}
+
+export function formatPercent(value: number, options: { showSign?: boolean } = {}): string {
+  const formatted = `${decimalFormatter.format(value)}%`;
+  if (options.showSign && value > 0) {
+    return `+${formatted}`;
+  }
+  return formatted;
+}
+
+export function formatTrend(value: number): string {
+  const formatted = decimalFormatter.format(value);
+  if (value > 0) {
+    return `+${formatted}`;
+  }
+  if (value < 0) {
+    return formatted;
+  }
+  return '0.0';
+}
+
+export function formatRenewablesShare(value: number): string {
+  return `${decimalFormatter.format(value)}%`;
+}
+
+export function formatCarbonIntensity(value: number): string {
+  return `${wholeNumberFormatter.format(value)} gCO₂/kWh`;
+}
+
+export function formatDateTime(isoDate: string): string {
+  return dateTimeFormatter.format(new Date(isoDate));
+}
+
+export function formatTimeLabel(isoDate: string): string {
+  return timeFormatter.format(new Date(isoDate));
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,20 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        slate: {
+          950: '#030712',
+        },
+      },
+      fontFamily: {
+        sans: ['"Inter"', 'system-ui', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -41,6 +41,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
+      "@/api/*": ["./src/api/*"],
       "@/components/*": ["./src/components/*"],
       "@/hooks/*": ["./src/hooks/*"],
       "@/services/*": ["./src/services/*"],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
+      '@/api': resolve(__dirname, './src/api'),
       '@/components': resolve(__dirname, './src/components'),
       '@/hooks': resolve(__dirname, './src/hooks'),
       '@/services': resolve(__dirname, './src/services'),


### PR DESCRIPTION
## Summary
- generate deterministic energy market series, forecasts and analytics with a new service layer and REST endpoints
- deliver a React 19 intelligence console with query-driven data fetching, charts, summaries and alerts
- document project capabilities and workflows plus configure Tailwind CSS for the dashboard

## Testing
- `mvn test` *(fails: offline environment cannot resolve Spring Boot artifacts)*
- `npm install` *(fails: registry access returns 403 so JS dependencies cannot be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5d6f3dfc833080c13aff3ed101e3